### PR TITLE
Fix issue #5: tell OS X that we don't need the discrete card

### DIFF
--- a/Objektiv/Objektiv-Info.plist
+++ b/Objektiv/Objektiv-Info.plist
@@ -34,6 +34,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>http://nthloop.com/objektiv/appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>


### PR DESCRIPTION
Essentially, tell OS X that Objektiv supports automatic graphics switching.

Otherwise, as soon as CoreAnimation is used, the system kicks over to the discrete card and remains there forevermore.