### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install
 
 The app works with Mac OS X 10.8 (Mountain Lion) onwards.
 
-You can either **[download Objektiv][download]** or install it via homebrew: `brew cask install objektiv`
+You can either **[download Objektiv][download]** or install it via homebrew: `brew install objektiv`
 
 Features
 ----------------------------------------


### PR DESCRIPTION
With a current brew version it is enough to `brew install objektiv`

```
$ brew --version
Homebrew 3.0.1
```

`$ brew cask install objektiv` will result in an error
Error: Unknown command: cask

I did not find a specific release note about it, but I suspect the recent 3.0 major release